### PR TITLE
Bruk aktørregister direkte fra frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM navikt/node-express:1.0.0
 WORKDIR /app
 
+RUN yarn add http-proxy-middleware
+
 COPY build/ build/
 COPY src/server/ src/server/
 

--- a/nais-dev-fss.json
+++ b/nais-dev-fss.json
@@ -30,6 +30,10 @@
             {
                 "name": "LOGIN_URL",
                 "value": "https://loginservice.nais.preprod.local/login?redirect=https://arbeidsgiver.nais.preprod.local/finn-kandidat/"
+            },
+            {
+                "name": "AKTORREGISTER_URL",
+                "value": "https://app-q0.adeo.no"
             }
         ]
     }

--- a/nais-prod-fss.json
+++ b/nais-prod-fss.json
@@ -30,6 +30,10 @@
             {
                 "name": "LOGIN_URL",
                 "value": "https://loginservice.nais.adeo.no/login?redirect=https://arbeidsgiver.nais.adeo.no/finn-kandidat/"
+            },
+            {
+                "name": "AKTORREGISTER_URL",
+                "value": "https://app.adeo.no"
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
         "axios-mock-adapter": "^1.16.0",
         "body-parser": "^1.18.3",
         "express": "^4.16.4",
-        "prettier": "^1.17.1"
+        "prettier": "^1.17.1",
+        "http-proxy-middleware": "^0.19.1"
     },
     "scripts": {
         "start": "craco start",

--- a/src/api/aktørregisterApi.ts
+++ b/src/api/aktørregisterApi.ts
@@ -5,15 +5,26 @@ import { randomCallId } from '../utils/randomIdUtils';
 const aktørIdUrl =
     '/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true';
 
+const fnrUrl = '/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=NorskIdent&gjeldende=true';
+
 export const hentAktørId = async (fnr: string): Promise<AxiosResponse<AktorIdResponse>> => {
     return await axios.get(aktørIdUrl, {
         withCredentials: true,
-        headers: {
-            'Nav-Consumer-Id': 'finn-kandidat',
-            'Nav-Call-Id': randomCallId(),
-            'Nav-Personidenter': fnr,
-        },
+        headers: lagHeaders(fnr),
     });
 };
 
-// TODO: hentFnr
+export const hentFnr = async (aktørId: string): Promise<AxiosResponse<AktorIdResponse>> => {
+    return await axios.get(fnrUrl, {
+        withCredentials: true,
+        headers: lagHeaders(aktørId),
+    });
+};
+
+const lagHeaders = (ident: string) => {
+    return {
+        'Nav-Consumer-Id': 'finn-kandidat',
+        'Nav-Call-Id': randomCallId(),
+        'Nav-Personidenter': ident,
+    };
+};

--- a/src/api/aktørregisterApi.ts
+++ b/src/api/aktørregisterApi.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosResponse } from 'axios';
+import { AktorIdResponse } from './aktørregisterUtils';
+import { randomCallId } from '../utils/randomIdUtils';
+
+const aktørIdUrl =
+    '/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true';
+
+// TODO: Rename
+export const hentAktørIdDirekte = async (fnr: string): Promise<AxiosResponse<AktorIdResponse>> => {
+    try {
+        return await axios.get(aktørIdUrl, {
+            withCredentials: true,
+            headers: {
+                'Nav-Consumer-Id': 'finn-kandidat',
+                'Nav-Call-Id': randomCallId(),
+                'Nav-Personidenter': fnr,
+            },
+        });
+    } catch (error) {
+        return Promise.reject(error.response);
+    }
+};
+
+// TODO: hentFnr

--- a/src/api/aktørregisterApi.ts
+++ b/src/api/aktørregisterApi.ts
@@ -5,20 +5,15 @@ import { randomCallId } from '../utils/randomIdUtils';
 const aktørIdUrl =
     '/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true';
 
-// TODO: Rename
-export const hentAktørIdDirekte = async (fnr: string): Promise<AxiosResponse<AktorIdResponse>> => {
-    try {
-        return await axios.get(aktørIdUrl, {
-            withCredentials: true,
-            headers: {
-                'Nav-Consumer-Id': 'finn-kandidat',
-                'Nav-Call-Id': randomCallId(),
-                'Nav-Personidenter': fnr,
-            },
-        });
-    } catch (error) {
-        return Promise.reject(error.response);
-    }
+export const hentAktørId = async (fnr: string): Promise<AxiosResponse<AktorIdResponse>> => {
+    return await axios.get(aktørIdUrl, {
+        withCredentials: true,
+        headers: {
+            'Nav-Consumer-Id': 'finn-kandidat',
+            'Nav-Call-Id': randomCallId(),
+            'Nav-Personidenter': fnr,
+        },
+    });
 };
 
 // TODO: hentFnr

--- a/src/api/aktørregisterUtils.ts
+++ b/src/api/aktørregisterUtils.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from 'axios';
 
 export interface AktorIdResponse {
-    [fnr: string]: Identinfo;
+    [ident: string]: Identinfo;
 }
 
 export interface Identinfo {
@@ -13,12 +13,12 @@ export interface Identinfo {
     }> | null;
 }
 
-export const hentGjeldendeAktørId = (
-    fnr: string,
+export const hentGjeldendeIdent = (
+    ident: string,
     respons: AxiosResponse<AktorIdResponse>
 ): string | undefined => {
     if (respons) {
-        const identinfo: Identinfo = respons.data[fnr];
+        const identinfo: Identinfo = respons.data[ident];
         if (identinfo && !identinfo.feilmelding && identinfo.identer) {
             const gjeldendeIdentinfo = identinfo.identer.find(ident => ident.gjeldende);
             if (gjeldendeIdentinfo) {

--- a/src/api/aktørregisterUtils.ts
+++ b/src/api/aktørregisterUtils.ts
@@ -1,0 +1,30 @@
+import { AxiosResponse } from 'axios';
+
+export interface AktorIdResponse {
+    [fnr: string]: Identinfo;
+}
+
+export interface Identinfo {
+    feilmelding: string | null;
+    identer: Array<{
+        gjeldende: boolean;
+        ident: string;
+        identgruppe: string;
+    }> | null;
+}
+
+export const hentGjeldendeAktørId = (
+    fnr: string,
+    respons: AxiosResponse<AktorIdResponse>
+): string | undefined => {
+    if (respons) {
+        const identinfo: Identinfo = respons.data[fnr];
+        if (identinfo && !identinfo.feilmelding && identinfo.identer) {
+            const gjeldendeIdentinfo = identinfo.identer.find(ident => ident.gjeldende);
+            if (gjeldendeIdentinfo) {
+                return gjeldendeIdentinfo.ident;
+            }
+        }
+    }
+    return undefined;
+};

--- a/src/api/finnKandidatApi.ts
+++ b/src/api/finnKandidatApi.ts
@@ -38,14 +38,6 @@ export const hentKandidat = async (aktørId: string): Promise<Kandidat> => {
     }
 };
 
-export const hentAktørId = async (fnr: string): Promise<AxiosResponse<string>> => {
-    try {
-        return await api.get(`/kandidater/${fnr}/aktorId`);
-    } catch (error) {
-        return Promise.reject(error.response);
-    }
-};
-
 export const hentFnr = async (aktørId: string): Promise<AxiosResponse<string>> => {
     try {
         return await api.get(`/kandidater/${aktørId}/fnr`);

--- a/src/api/finnKandidatApi.ts
+++ b/src/api/finnKandidatApi.ts
@@ -4,6 +4,8 @@ import api from './initialize';
 import { Kandidat } from '../types/Kandidat';
 import { LovligeBehov } from '../pages/registrering/tilbakemelding/Tilbakemelding';
 import { AxiosResponse } from 'axios';
+import { randomCallId } from '../utils/randomIdUtils';
+import { AktorIdResponse, hentGjeldendeAktørId, Identinfo } from './aktørregisterUtils';
 
 type KandidatDto = Omit<Kandidat, 'arbeidstidBehov'> & {
     arbeidstidBehov: ArbeidstidBehov;
@@ -41,6 +43,21 @@ export const hentKandidat = async (aktørId: string): Promise<Kandidat> => {
 export const hentAktørId = async (fnr: string): Promise<AxiosResponse<string>> => {
     try {
         return await api.get(`/kandidater/${fnr}/aktorId`);
+    } catch (error) {
+        return Promise.reject(error.response);
+    }
+};
+
+export const hentAktørIdDirekte = async (fnr: string): Promise<AxiosResponse<AktorIdResponse>> => {
+    try {
+        return await api.get('/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true', {
+            withCredentials: true,
+            headers: {
+                'Nav-Consumer-Id': 'finn-kandidat',
+                'Nav-Call-Id': randomCallId(),
+                'Nav-Personidenter': fnr,
+            },
+        });
     } catch (error) {
         return Promise.reject(error.response);
     }

--- a/src/api/finnKandidatApi.ts
+++ b/src/api/finnKandidatApi.ts
@@ -5,7 +5,7 @@ import { Kandidat } from '../types/Kandidat';
 import { LovligeBehov } from '../pages/registrering/tilbakemelding/Tilbakemelding';
 import { AxiosResponse } from 'axios';
 import { randomCallId } from '../utils/randomIdUtils';
-import { AktorIdResponse, hentGjeldendeAktørId, Identinfo } from './aktørregisterUtils';
+import { AktorIdResponse } from './aktørregisterUtils';
 
 type KandidatDto = Omit<Kandidat, 'arbeidstidBehov'> & {
     arbeidstidBehov: ArbeidstidBehov;

--- a/src/api/finnKandidatApi.ts
+++ b/src/api/finnKandidatApi.ts
@@ -3,7 +3,6 @@ import { Omit } from 'react-router';
 import api from './initialize';
 import { Kandidat } from '../types/Kandidat';
 import { LovligeBehov } from '../pages/registrering/tilbakemelding/Tilbakemelding';
-import { AxiosResponse } from 'axios';
 
 type KandidatDto = Omit<Kandidat, 'arbeidstidBehov'> & {
     arbeidstidBehov: ArbeidstidBehov;
@@ -33,14 +32,6 @@ export const hentKandidat = async (aktørId: string): Promise<Kandidat> => {
     try {
         const respons = await api.get(`/kandidater/${aktørId}`);
         return fraKandidatDto(respons.data);
-    } catch (error) {
-        return Promise.reject(error.response);
-    }
-};
-
-export const hentFnr = async (aktørId: string): Promise<AxiosResponse<string>> => {
-    try {
-        return await api.get(`/kandidater/${aktørId}/fnr`);
     } catch (error) {
         return Promise.reject(error.response);
     }

--- a/src/api/finnKandidatApi.ts
+++ b/src/api/finnKandidatApi.ts
@@ -48,21 +48,6 @@ export const hentAktørId = async (fnr: string): Promise<AxiosResponse<string>> 
     }
 };
 
-export const hentAktørIdDirekte = async (fnr: string): Promise<AxiosResponse<AktorIdResponse>> => {
-    try {
-        return await api.get('/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true', {
-            withCredentials: true,
-            headers: {
-                'Nav-Consumer-Id': 'finn-kandidat',
-                'Nav-Call-Id': randomCallId(),
-                'Nav-Personidenter': fnr,
-            },
-        });
-    } catch (error) {
-        return Promise.reject(error.response);
-    }
-};
-
 export const hentFnr = async (aktørId: string): Promise<AxiosResponse<string>> => {
     try {
         return await api.get(`/kandidater/${aktørId}/fnr`);

--- a/src/api/finnKandidatApi.ts
+++ b/src/api/finnKandidatApi.ts
@@ -4,8 +4,6 @@ import api from './initialize';
 import { Kandidat } from '../types/Kandidat';
 import { LovligeBehov } from '../pages/registrering/tilbakemelding/Tilbakemelding';
 import { AxiosResponse } from 'axios';
-import { randomCallId } from '../utils/randomIdUtils';
-import { AktorIdResponse } from './aktørregisterUtils';
 
 type KandidatDto = Omit<Kandidat, 'arbeidstidBehov'> & {
     arbeidstidBehov: ArbeidstidBehov;

--- a/src/mocking/mockApi.ts
+++ b/src/mocking/mockApi.ts
@@ -1,110 +1,70 @@
 import MockAdapter from 'axios-mock-adapter';
 import { Kandidat } from '../types/Kandidat';
+import {
+    aktørIdFraUrl,
+    kandidatFraMock,
+    ingenIdenterRespons,
+    visAdvarsel,
+    aktørIdRespons,
+    fnrRespons,
+} from './mockUtils';
 import api from '../api/initialize';
-import { AktorIdResponse } from '../api/aktørregisterUtils';
-
-const ROUTE_KANDIDATER = '/finn-kandidat-api/kandidater';
-const ROUTE_EVENTS = '/finn-kandidat-api/events';
-const ROUTE_TILBAKEMELDING = '/finn-kandidat-api/tilbakemeldinger';
-const ROUTE_KANDIDAT = /\/finn-kandidat-api\/kandidater\/\d+/;
-const ROUTE_SKRIVETILGANG = /\/finn-kandidat-api\/kandidater\/\d+\/skrivetilgang/;
-const ROUTE_AKTØRID = /\/finn-kandidat-api\/kandidater\/\d+\/aktorId/;
-const ROUTE_FNR = /\/finn-kandidat-api\/kandidater\/\d+\/fnr/;
-const ROUTE_AKTØRID_DIREKTE =
-    '/finn-kandidat-api/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true';
-
+import axios from 'axios';
 const kandidater = require('./kandidater.json');
-const mock = new MockAdapter(api, {
-    delayResponse: 200,
+
+const kandidaterUrl = '/finn-kandidat-api/kandidater';
+const eventsUrl = '/finn-kandidat-api/events';
+const tilbakemeldingerUrl = '/finn-kandidat-api/tilbakemeldinger';
+const kandidatUrl = /\/finn-kandidat-api\/kandidater\/\d+/;
+const skrivetilgangUrl = /\/finn-kandidat-api\/kandidater\/\d+\/skrivetilgang/;
+const hentAktørIdUrl =
+    '/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true';
+const hentFnrUrl =
+    '/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=NorskIdent&gjeldende=true';
+
+const finnKandidatMock = new MockAdapter(api, { delayResponse: 200 });
+const aktørregisterMock = new MockAdapter(axios, { delayResponse: 200 });
+
+finnKandidatMock.onGet(kandidatUrl).reply(config => {
+    const aktørId = aktørIdFraUrl(config);
+    const kandidat = kandidatFraMock(aktørId);
+    return kandidat ? [200, kandidat] : [404];
 });
 
-const visAdvarsel = () => {
-    const bigFontCss =
-        'font-size: 3rem; font-weight: bold; font-family: georgia; color: skyblue; text-shadow: 1px 1px 0 black';
-    const smallerFontCss = 'font-size: 1.075rem; color: skyblue; font-family: georgia;';
-
-    console.log('%cMOCKED API', bigFontCss);
-    console.log('%cDETTE SKAL IKKE VISES I PRODUKSJON!\n', smallerFontCss);
-};
-visAdvarsel();
-
-mock.onGet(ROUTE_SKRIVETILGANG).reply(() => [200]);
-
-mock.onGet(ROUTE_AKTØRID).reply(config => {
-    const fnrFraRoute = hentFnrFraConfig(config);
-    const kandidatFraMock: Kandidat = kandidater.find(
-        (kandidat: Kandidat) => kandidat.fnr === fnrFraRoute
-    );
-
-    return [200, kandidatFraMock.aktørId];
+finnKandidatMock.onDelete(kandidatUrl).reply(config => {
+    const aktørId = aktørIdFraUrl(config);
+    const kandidat = kandidatFraMock(aktørId);
+    return kandidat ? [200] : [404];
 });
 
-mock.onGet(ROUTE_AKTØRID_DIREKTE).reply(config => {
-    const fnr = config.headers['Nav-Personidenter'];
-    const kandidat: Kandidat = kandidater.find((kandidat: Kandidat) => kandidat.fnr === fnr);
-
-    if (kandidat) {
-        const respons: AktorIdResponse = {
-            [fnr]: {
-                identer: [
-                    {
-                        ident: kandidat.aktørId,
-                        identgruppe: 'AktoerId',
-                        gjeldende: true,
-                    },
-                ],
-                feilmelding: null,
-            },
-        };
-        return [200, respons];
-    } else {
-        const responsUtenIdenter: AktorIdResponse = {
-            [fnr]: {
-                identer: null,
-                feilmelding: 'Den angitte personidenten finnes ikke',
-            },
-        };
-        return [200, responsUtenIdenter];
-    }
-});
-
-mock.onGet(ROUTE_FNR).reply(config => {
-    const aktørIdFraRoute = hentAktørIdFraConfig(config);
-    const kandidatFraMock: Kandidat = kandidater.find(
-        (kandidat: Kandidat) => kandidat.aktørId === aktørIdFraRoute
-    );
-
-    return [200, kandidatFraMock.fnr];
-});
-
-mock.onGet(ROUTE_KANDIDAT).reply(config => {
-    const aktørIdFraUrl = hentAktørIdFraConfig(config);
-    const kandidatFraMock = kandidater.find(
-        (kandidat: Kandidat) => kandidat.aktørId === aktørIdFraUrl
-    );
-
-    return kandidatFraMock ? [200, kandidatFraMock] : [404];
-});
-
-mock.onDelete(ROUTE_KANDIDAT).reply(config => {
-    const aktørIdFraRoute = hentAktørIdFraConfig(config);
-    const kandidatFraMock = kandidater.find(
-        (kandidat: Kandidat) => kandidat.aktørId === aktørIdFraRoute
-    );
-
-    return kandidatFraMock ? [200] : [404];
-});
-
-mock.onGet(ROUTE_KANDIDATER).reply(() => [200, kandidater]);
-mock.onPost(ROUTE_KANDIDATER).reply(config => [201, config.data]);
-mock.onPut(ROUTE_KANDIDATER).reply(config => [200, config.data]);
-
-mock.onPost(ROUTE_EVENTS).reply(config => {
+finnKandidatMock.onGet(kandidaterUrl).reply(200, kandidater);
+finnKandidatMock.onPost(kandidaterUrl).reply(config => [201, config.data]);
+finnKandidatMock.onPut(kandidaterUrl).reply(config => [200, config.data]);
+finnKandidatMock.onGet(skrivetilgangUrl).reply(200);
+finnKandidatMock.onPost(tilbakemeldingerUrl).reply(201);
+finnKandidatMock.onPost(eventsUrl).reply(config => {
     console.log('Sender event', config.data);
     return [200];
 });
 
-mock.onPost(ROUTE_TILBAKEMELDING).reply(() => [201]);
+aktørregisterMock.onGet(hentAktørIdUrl).reply(config => {
+    const fnr = config.headers['Nav-Personidenter'];
+    const kandidat: Kandidat = kandidater.find((kandidat: Kandidat) => kandidat.fnr === fnr);
+    if (kandidat) {
+        return [200, aktørIdRespons(fnr, kandidat.aktørId)];
+    } else {
+        return [200, ingenIdenterRespons(fnr)];
+    }
+});
 
-const hentFnrFraConfig = (config: any) => config.url && config.url.split('/')[3];
-const hentAktørIdFraConfig = (config: any) => config.url && config.url.split('/')[3];
+aktørregisterMock.onGet(hentFnrUrl).reply(config => {
+    const aktørId = config.headers['Nav-Personidenter'];
+    const kandidat = kandidatFraMock(aktørId);
+    if (kandidat) {
+        return [200, fnrRespons(aktørId, kandidat.fnr)];
+    } else {
+        return [200, ingenIdenterRespons(aktørId)];
+    }
+});
+
+visAdvarsel();

--- a/src/mocking/mockUtils.ts
+++ b/src/mocking/mockUtils.ts
@@ -1,0 +1,37 @@
+import { Kandidat } from '../types/Kandidat';
+
+const kandidater = require('./kandidater.json');
+
+export const kandidatFraMock = (aktørId: string) => {
+    return kandidater.find((kandidat: Kandidat) => kandidat.aktørId === aktørId);
+};
+
+export const hentFnrFraConfig = (config: any) => config.url && config.url.split('/')[3];
+export const aktørIdFraUrl = (config: any) => config.url && config.url.split('/')[3];
+
+export const aktørIdRespons = (fnr: string, aktørId: string) => ({
+    [fnr]: {
+        identer: [{ ident: aktørId, identgruppe: 'AktoerId', gjeldende: true }],
+        feilmelding: null,
+    },
+});
+
+export const fnrRespons = (aktørId: string, fnr: string) => ({
+    [aktørId]: {
+        identer: [{ ident: fnr, identgruppe: 'NorskIdent', gjeldende: true }],
+        feilmelding: null,
+    },
+});
+
+export const ingenIdenterRespons = (ident: string) => ({
+    [ident]: { identer: null, feilmelding: 'Den angitte personidenten finnes ikke' },
+});
+
+export const visAdvarsel = () => {
+    const bigFontCss =
+        'font-size: 3rem; font-weight: bold; font-family: georgia; color: skyblue; text-shadow: 1px 1px 0 black';
+    const smallerFontCss = 'font-size: 1.075rem; color: skyblue; font-family: georgia;';
+
+    console.log('%cMOCKED API', bigFontCss);
+    console.log('%cDETTE SKAL IKKE VISES I PRODUKSJON!\n', smallerFontCss);
+};

--- a/src/pages/før-du-begynner/FørDuBegynner.tsx
+++ b/src/pages/før-du-begynner/FørDuBegynner.tsx
@@ -8,17 +8,14 @@ import Brødsmulesti from '../../components/brødsmulesti/Brødsmulesti';
 import FnrInput from './fnr-input/FnrInput';
 import RouteBanner from '../../components/route-banner/RouteBanner';
 import './førDuBegynner.less';
-import useAktørId, { TilgangsStatus } from './useAktørId';
+import { useAktørId, TilgangsStatus } from './useAktørId';
 
 const cls = bemHelper('førDuBegynner');
 
 const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => {
     const [fnr, setFnr] = useState<string>('');
-    const [sjekkerTilgangOgEksistens, setSjekkerTilgangOgEksistens] = useState<boolean>(false);
-
-    const { aktørId, tilgangsstatus, kandidatEksisterer } = useAktørId(
-        fnr,
-        sjekkerTilgangOgEksistens
+    const { aktørId, tilgangsstatus, kandidatEksisterer, henterAktørId, hentAktørId } = useAktørId(
+        fnr
     );
 
     const redirectTil = useCallback(
@@ -29,25 +26,18 @@ const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => 
     );
 
     useEffect(() => {
-        if (tilgangsstatus !== TilgangsStatus.IngenFeil) {
-            setSjekkerTilgangOgEksistens(false);
-        } else if (kandidatEksisterer && aktørId) {
+        if (kandidatEksisterer && aktørId) {
             redirectTil(AppRoute.EndreKandidat, aktørId);
         } else if (aktørId) {
             redirectTil(AppRoute.Registrering, aktørId);
         }
-    }, [aktørId, tilgangsstatus, kandidatEksisterer, redirectTil]);
-
-    const handleFnrChange = (fnr: string) => {
-        setFnr(fnr);
-        setSjekkerTilgangOgEksistens(false);
-    };
+    }, [aktørId, kandidatEksisterer, redirectTil]);
 
     const onGåVidereKlikk = () => {
         if (process.env.REACT_APP_MOCK) {
             redirectTil(AppRoute.Registrering, '1856024171652');
         }
-        setSjekkerTilgangOgEksistens(true);
+        hentAktørId();
     };
 
     return (
@@ -57,13 +47,13 @@ const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => 
                 <Brødsmulesti sidenDuErPå={AppRoute.FørDuBegynner} />
                 <FnrInput
                     fnr={fnr}
-                    onFnrChange={handleFnrChange}
+                    onFnrChange={setFnr}
                     feilmelding={
                         tilgangsstatus === TilgangsStatus.IngenFeil ? undefined : tilgangsstatus
                     }
                 />
                 <Hovedknapp
-                    spinner={sjekkerTilgangOgEksistens}
+                    spinner={henterAktørId}
                     className={cls.element('knapp')}
                     onClick={onGåVidereKlikk}
                 >

--- a/src/pages/før-du-begynner/FørDuBegynner.tsx
+++ b/src/pages/før-du-begynner/FørDuBegynner.tsx
@@ -8,13 +8,13 @@ import Brødsmulesti from '../../components/brødsmulesti/Brødsmulesti';
 import FnrInput from './fnr-input/FnrInput';
 import RouteBanner from '../../components/route-banner/RouteBanner';
 import './førDuBegynner.less';
-import { useAktørId, TilgangsStatus } from './useAktørId';
+import { useAktørId } from './useAktørId';
 
 const cls = bemHelper('førDuBegynner');
 
 const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => {
     const [fnr, setFnr] = useState<string>('');
-    const { aktørId, tilgangsstatus, kandidatEksisterer, henterAktørId, hentAktørId } = useAktørId(
+    const { aktørId, feilmelding, kandidatEksisterer, henterAktørId, hentAktørId } = useAktørId(
         fnr
     );
 
@@ -45,13 +45,7 @@ const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => 
             <RouteBanner tittel="Registrer eller endre kandidat" />
             <main className={cls.block}>
                 <Brødsmulesti sidenDuErPå={AppRoute.FørDuBegynner} />
-                <FnrInput
-                    fnr={fnr}
-                    onFnrChange={setFnr}
-                    feilmelding={
-                        tilgangsstatus === TilgangsStatus.IngenFeil ? undefined : tilgangsstatus
-                    }
-                />
+                <FnrInput fnr={fnr} onFnrChange={setFnr} feilmelding={feilmelding} />
                 <Hovedknapp
                     spinner={henterAktørId}
                     className={cls.element('knapp')}

--- a/src/pages/før-du-begynner/FørDuBegynner.tsx
+++ b/src/pages/før-du-begynner/FørDuBegynner.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { RouteComponentProps, withRouter } from 'react-router';
 
@@ -12,11 +12,8 @@ import useAktørId, { TilgangsStatus } from './useAktørId';
 
 const cls = bemHelper('førDuBegynner');
 
-const FørDuBegynner: FunctionComponent<RouteComponentProps> = props => {
+const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => {
     const [fnr, setFnr] = useState<string>('');
-    // const [feilmelding, setFeilmelding] = useState<TilgangsStatus | undefined>(
-    //     TilgangsStatus.IngenFeil
-    // );
     const [sjekkerTilgangOgEksistens, setSjekkerTilgangOgEksistens] = useState<boolean>(false);
 
     const { aktørId, tilgangsstatus, kandidatEksisterer } = useAktørId(
@@ -24,32 +21,31 @@ const FørDuBegynner: FunctionComponent<RouteComponentProps> = props => {
         sjekkerTilgangOgEksistens
     );
 
+    const redirectTil = useCallback(
+        (route: AppRoute, aktørId: string) => {
+            history.push(hentRoute(route, aktørId));
+        },
+        [history]
+    );
+
+    useEffect(() => {
+        if (tilgangsstatus !== TilgangsStatus.IngenFeil) {
+            setSjekkerTilgangOgEksistens(false);
+        } else if (kandidatEksisterer && aktørId) {
+            redirectTil(AppRoute.EndreKandidat, aktørId);
+        } else if (aktørId) {
+            redirectTil(AppRoute.Registrering, aktørId);
+        }
+    }, [aktørId, tilgangsstatus, kandidatEksisterer, redirectTil]);
+
     const handleFnrChange = (fnr: string) => {
         setFnr(fnr);
-        // setFeilmelding(TilgangsStatus.IngenFeil);
         setSjekkerTilgangOgEksistens(false);
     };
 
     const onGåVidereKlikk = () => {
         setSjekkerTilgangOgEksistens(true);
     };
-
-    const redirectTil = (route: AppRoute, aktørId: string) => {
-        props.history.push(hentRoute(route, aktørId));
-    };
-
-    useEffect(() => {
-        if (tilgangsstatus !== TilgangsStatus.IngenFeil) {
-            // setFeilmelding(tilgangsstatus);
-            setSjekkerTilgangOgEksistens(false);
-
-            console.log('Feilmelding. Verdier:', aktørId, tilgangsstatus, kandidatEksisterer);
-        } else if (kandidatEksisterer && aktørId) {
-            redirectTil(AppRoute.EndreKandidat, aktørId);
-        } else if (aktørId) {
-            redirectTil(AppRoute.Registrering, aktørId);
-        }
-    }, [aktørId, tilgangsstatus, kandidatEksisterer]);
 
     return (
         <>

--- a/src/pages/før-du-begynner/FørDuBegynner.tsx
+++ b/src/pages/før-du-begynner/FørDuBegynner.tsx
@@ -44,6 +44,9 @@ const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => 
     };
 
     const onGåVidereKlikk = () => {
+        if (process.env.REACT_APP_MOCK) {
+            redirectTil(AppRoute.Registrering, '1856024171652');
+        }
         setSjekkerTilgangOgEksistens(true);
     };
 

--- a/src/pages/før-du-begynner/FørDuBegynner.tsx
+++ b/src/pages/før-du-begynner/FørDuBegynner.tsx
@@ -1,99 +1,68 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { RouteComponentProps, withRouter } from 'react-router';
 
 import { AppRoute, hentRoute } from '../../utils/paths';
-import { erGyldigFnr, erTom } from './fnr-input/fnrUtils';
-import { hentSkrivetilgang, hentAktørId, hentKandidat } from '../../api/finnKandidatApi';
 import bemHelper from '../../utils/bemHelper';
 import Brødsmulesti from '../../components/brødsmulesti/Brødsmulesti';
 import FnrInput from './fnr-input/FnrInput';
 import RouteBanner from '../../components/route-banner/RouteBanner';
 import './førDuBegynner.less';
+import useAktørId, { TilgangsStatus } from './useAktørId';
 
 const cls = bemHelper('førDuBegynner');
 
-enum Feilmelding {
-    TomtFødselsnummer = 'Vennligst fyll ut fødselsnummer',
-    UgyldigFødselsnummer = 'Fødselsnummeret er ugyldig',
-    IngenTilgang = 'Du har enten ikke tilgang til denne kandidaten eller så finnes ikke kandidaten i systemet',
-    Serverfeil = 'Det skjedde dessverre en feil',
-}
-
 const FørDuBegynner: FunctionComponent<RouteComponentProps> = props => {
     const [fnr, setFnr] = useState<string>('');
+    // const [feilmelding, setFeilmelding] = useState<TilgangsStatus | undefined>(
+    //     TilgangsStatus.IngenFeil
+    // );
+    const [sjekkerTilgangOgEksistens, setSjekkerTilgangOgEksistens] = useState<boolean>(false);
 
-    const [feilmelding, setFeilmelding] = useState<Feilmelding | undefined>(undefined);
-    const [sjekkerTilgangOgEksistens, setSjekkerTilgangOgEksistens] = useState<boolean>();
+    const { aktørId, tilgangsstatus, kandidatEksisterer } = useAktørId(
+        fnr,
+        sjekkerTilgangOgEksistens
+    );
 
     const handleFnrChange = (fnr: string) => {
         setFnr(fnr);
-        setFeilmelding(undefined);
+        // setFeilmelding(TilgangsStatus.IngenFeil);
+        setSjekkerTilgangOgEksistens(false);
     };
 
-    // TODO: Rydd opp i denne funksjonen ved å legge inn RestKandidat
-    const onGåVidereKlikk = async () => {
-        // Kun i Mock
-        if (process.env.REACT_APP_MOCK) {
-            redirectTil(AppRoute.Registrering, '1856024171652');
-            return;
-        }
-
-        // Valider fnr
-        if (erTom(fnr)) {
-            setFeilmelding(Feilmelding.TomtFødselsnummer);
-            return;
-        }
-        if (!erGyldigFnr(fnr)) {
-            setFeilmelding(Feilmelding.UgyldigFødselsnummer);
-            return;
-        }
-
-        // Hent aktørId
-        let aktørId: string = '';
-        try {
-            const response = await hentAktørId(fnr);
-            aktørId = response.data;
-        } catch (error) {
-            if (error.response.status === 400) {
-                setFeilmelding(Feilmelding.UgyldigFødselsnummer);
-                return;
-            } else if (error.response.status === 500) {
-                setFeilmelding(Feilmelding.Serverfeil);
-                return;
-            }
-        } finally {
-            setSjekkerTilgangOgEksistens(true);
-        }
-
-        // Hent skrivetilgang
-        const harSkrivetilgang = await hentSkrivetilgang(aktørId);
-        if (!harSkrivetilgang) {
-            setFeilmelding(Feilmelding.IngenTilgang);
-            return;
-        }
-
-        // Kandidat fins fra før eller ikke?
-        setSjekkerTilgangOgEksistens(false);
-        try {
-            const kandidat = await hentKandidat(aktørId);
-            redirectTil(AppRoute.EndreKandidat, kandidat.aktørId);
-        } catch (error) {
-            // Kandidat eksisterer ikke
-            redirectTil(AppRoute.Registrering, aktørId);
-        }
+    const onGåVidereKlikk = () => {
+        setSjekkerTilgangOgEksistens(true);
     };
 
     const redirectTil = (route: AppRoute, aktørId: string) => {
         props.history.push(hentRoute(route, aktørId));
     };
 
+    useEffect(() => {
+        if (tilgangsstatus !== TilgangsStatus.IngenFeil) {
+            // setFeilmelding(tilgangsstatus);
+            setSjekkerTilgangOgEksistens(false);
+
+            console.log('Feilmelding. Verdier:', aktørId, tilgangsstatus, kandidatEksisterer);
+        } else if (kandidatEksisterer && aktørId) {
+            redirectTil(AppRoute.EndreKandidat, aktørId);
+        } else if (aktørId) {
+            redirectTil(AppRoute.Registrering, aktørId);
+        }
+    }, [aktørId, tilgangsstatus, kandidatEksisterer]);
+
     return (
         <>
             <RouteBanner tittel="Registrer eller endre kandidat" />
             <main className={cls.block}>
                 <Brødsmulesti sidenDuErPå={AppRoute.FørDuBegynner} />
-                <FnrInput fnr={fnr} onFnrChange={handleFnrChange} feilmelding={feilmelding} />
+                <FnrInput
+                    fnr={fnr}
+                    onFnrChange={handleFnrChange}
+                    feilmelding={
+                        tilgangsstatus === TilgangsStatus.IngenFeil ? undefined : tilgangsstatus
+                    }
+                />
                 <Hovedknapp
                     spinner={sjekkerTilgangOgEksistens}
                     className={cls.element('knapp')}

--- a/src/pages/før-du-begynner/FørDuBegynner.tsx
+++ b/src/pages/før-du-begynner/FørDuBegynner.tsx
@@ -26,12 +26,14 @@ const FørDuBegynner: FunctionComponent<RouteComponentProps> = ({ history }) => 
     );
 
     useEffect(() => {
-        if (kandidatEksisterer && aktørId) {
+        if (henterAktørId || !aktørId) return;
+
+        if (kandidatEksisterer) {
             redirectTil(AppRoute.EndreKandidat, aktørId);
-        } else if (aktørId) {
+        } else {
             redirectTil(AppRoute.Registrering, aktørId);
         }
-    }, [aktørId, kandidatEksisterer, redirectTil]);
+    }, [aktørId, kandidatEksisterer, henterAktørId, redirectTil]);
 
     const onGåVidereKlikk = () => {
         if (process.env.REACT_APP_MOCK) {

--- a/src/pages/før-du-begynner/useAktørId.ts
+++ b/src/pages/før-du-begynner/useAktørId.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { hentAktørIdDirekte, hentKandidat, hentSkrivetilgang } from '../../api/finnKandidatApi';
 import { hentGjeldendeAktørId } from '../../api/aktørregisterUtils';
 import { erGyldigFnr, erTom } from './fnr-input/fnrUtils';
@@ -22,7 +22,7 @@ const useAktørId = (fnr: string, sjekkerTilgangOgEksistens: boolean): AktørIdO
     const [tilgangsstatus, setTilgangsstatus] = useState<TilgangsStatus>(TilgangsStatus.IngenFeil);
     const [kandidatEksisterer, setKandidatEksisterer] = useState<boolean>(false);
 
-    const hentAktørIdOgSjekkTilgang = async () => {
+    const hentAktørIdOgSjekkTilgang = useCallback(async () => {
         try {
             validerFnr(fnr);
             const gjeldendeAktørId = await hentAktørId(fnr);
@@ -33,13 +33,13 @@ const useAktørId = (fnr: string, sjekkerTilgangOgEksistens: boolean): AktørIdO
         } catch (status) {
             setTilgangsstatus(status);
         }
-    };
+    }, [fnr]);
 
     useEffect(() => {
         if (sjekkerTilgangOgEksistens) {
             hentAktørIdOgSjekkTilgang();
         }
-    }, [sjekkerTilgangOgEksistens]);
+    }, [sjekkerTilgangOgEksistens, hentAktørIdOgSjekkTilgang]);
 
     useEffect(() => {
         setTilgangsstatus(TilgangsStatus.IngenFeil);

--- a/src/pages/før-du-begynner/useAktørId.ts
+++ b/src/pages/før-du-begynner/useAktørId.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { hentKandidat, hentSkrivetilgang } from '../../api/finnKandidatApi';
-import { hentGjeldendeAktørId } from '../../api/aktørregisterUtils';
+import { hentGjeldendeIdent } from '../../api/aktørregisterUtils';
 import { erGyldigFnr, erTom } from './fnr-input/fnrUtils';
 import { hentAktørId } from '../../api/aktørregisterApi';
 
@@ -71,7 +71,7 @@ const hentOgSjekkAktørId = async (fnr: string) => {
         throw TilgangsStatus.IngenTilgangEllerIkkeFinnes;
     }
 
-    const gjeldendeAktørId = hentGjeldendeAktørId(fnr, respons);
+    const gjeldendeAktørId = hentGjeldendeIdent(fnr, respons);
     if (gjeldendeAktørId) {
         return gjeldendeAktørId;
     } else {

--- a/src/pages/før-du-begynner/useAktørId.ts
+++ b/src/pages/før-du-begynner/useAktørId.ts
@@ -9,7 +9,6 @@ export enum Feilmelding {
     UgyldigFødselsnummer = 'Fødselsnummeret er ugyldig',
     IngenTilgangEllerIkkeFinnes = 'Du har enten ikke tilgang til denne kandidaten eller så finnes ikke kandidaten i systemet',
     Serverfeil = 'Det skjedde dessverre en feil',
-    IngenFeil = 'Ingen feil',
 }
 
 export interface AktørIdOgStatus {
@@ -32,18 +31,17 @@ export const useAktørId = (fnr: string): AktørIdOgStatus => {
             setHenterAktørId(true);
             const gjeldendeAktørId = await hentOgSjekkAktørId(fnr);
             await sjekkSkrivetilgang(gjeldendeAktørId);
-            await sjekkKandidatEksisterer(gjeldendeAktørId);
+            const eksisterer = await sjekkKandidatEksisterer(gjeldendeAktørId);
+            setKandidatEksisterer(eksisterer);
             setAktørId(gjeldendeAktørId);
-            setKandidatEksisterer(true);
         } catch (status) {
             setFeilmelding(status);
+        } finally {
             setHenterAktørId(false);
         }
     }, [fnr]);
 
-    useEffect(() => {
-        setFeilmelding(undefined);
-    }, [fnr]);
+    useEffect(() => setFeilmelding(undefined), [fnr]);
 
     return {
         aktørId,
@@ -94,7 +92,8 @@ const sjekkSkrivetilgang = async (aktørId: string) => {
 const sjekkKandidatEksisterer = async (aktørId: string) => {
     try {
         await hentKandidat(aktørId);
+        return true;
     } catch (ignored) {
-        throw Feilmelding.IngenTilgangEllerIkkeFinnes;
+        return false;
     }
 };

--- a/src/pages/før-du-begynner/useAktørId.ts
+++ b/src/pages/før-du-begynner/useAktørId.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { hentAktørIdDirekte, hentKandidat, hentSkrivetilgang } from '../../api/finnKandidatApi';
+import { hentGjeldendeAktørId } from '../../api/aktørregisterUtils';
+import { erGyldigFnr, erTom } from './fnr-input/fnrUtils';
+
+export enum TilgangsStatus {
+    TomtFødselsnummer = 'Vennligst fyll ut fødselsnummer',
+    UgyldigFødselsnummer = 'Fødselsnummeret er ugyldig',
+    IngenTilgangEllerIkkeFinnes = 'Du har enten ikke tilgang til denne kandidaten eller så finnes ikke kandidaten i systemet',
+    Serverfeil = 'Det skjedde dessverre en feil',
+    IngenFeil = 'Ingen feil',
+}
+
+export interface AktørIdOgStatus {
+    aktørId?: string;
+    tilgangsstatus: TilgangsStatus;
+    kandidatEksisterer: boolean;
+}
+
+const useAktørId = (fnr: string, sjekkerTilgangOgEksistens: boolean): AktørIdOgStatus => {
+    const [aktørId, setAktørId] = useState<string | undefined>(undefined);
+    const [tilgangsstatus, setTilgangsstatus] = useState<TilgangsStatus>(TilgangsStatus.IngenFeil);
+    const [kandidatEksisterer, setKandidatEksisterer] = useState<boolean>(false);
+
+    const hentAktørIdOgSjekkTilgang = async () => {
+        try {
+            validerFnr(fnr);
+            const gjeldendeAktørId = await hentAktørId(fnr);
+            await sjekkSkrivetilgang(gjeldendeAktørId);
+            await sjekkKandidatEksisterer(gjeldendeAktørId);
+            setAktørId(gjeldendeAktørId);
+            setKandidatEksisterer(true);
+        } catch (status) {
+            setTilgangsstatus(status);
+        }
+    };
+
+    useEffect(() => {
+        if (sjekkerTilgangOgEksistens) {
+            hentAktørIdOgSjekkTilgang();
+        }
+    }, [sjekkerTilgangOgEksistens]);
+
+    useEffect(() => {
+        setTilgangsstatus(TilgangsStatus.IngenFeil);
+    }, [fnr]);
+
+    return { aktørId, tilgangsstatus, kandidatEksisterer };
+};
+
+const validerFnr = (fnr: string) => {
+    if (erTom(fnr)) {
+        throw TilgangsStatus.TomtFødselsnummer;
+    } else if (!erGyldigFnr(fnr)) {
+        throw TilgangsStatus.UgyldigFødselsnummer;
+    }
+};
+
+const hentAktørId = async (fnr: string) => {
+    try {
+        const respons = await hentAktørIdDirekte(fnr);
+        const gjeldendeAktørId = hentGjeldendeAktørId(fnr, respons);
+        if (gjeldendeAktørId) {
+            return gjeldendeAktørId;
+        }
+    } catch (ignored) {}
+    throw TilgangsStatus.Serverfeil;
+};
+
+const sjekkSkrivetilgang = async (aktørId: string) => {
+    const harSkrivetilgang = await hentSkrivetilgang(aktørId);
+    if (!harSkrivetilgang) {
+        throw TilgangsStatus.IngenTilgangEllerIkkeFinnes;
+    }
+};
+
+const sjekkKandidatEksisterer = async (aktørId: string) => {
+    try {
+        await hentKandidat(aktørId);
+    } catch (ignored) {
+        throw TilgangsStatus.IngenTilgangEllerIkkeFinnes;
+    }
+};
+
+export default useAktørId;

--- a/src/pages/før-du-begynner/useAktørId.ts
+++ b/src/pages/før-du-begynner/useAktørId.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { hentKandidat, hentSkrivetilgang } from '../../api/finnKandidatApi';
-import { AktorIdResponse, hentGjeldendeAktørId } from '../../api/aktørregisterUtils';
+import { hentGjeldendeAktørId } from '../../api/aktørregisterUtils';
 import { erGyldigFnr, erTom } from './fnr-input/fnrUtils';
 import { hentAktørIdDirekte } from '../../api/aktørregisterApi';
 

--- a/src/pages/før-du-begynner/useAktørId.ts
+++ b/src/pages/før-du-begynner/useAktørId.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { hentKandidat, hentSkrivetilgang } from '../../api/finnKandidatApi';
 import { hentGjeldendeAktørId } from '../../api/aktørregisterUtils';
 import { erGyldigFnr, erTom } from './fnr-input/fnrUtils';
-import { hentAktørIdDirekte } from '../../api/aktørregisterApi';
+import { hentAktørId } from '../../api/aktørregisterApi';
 
 export enum TilgangsStatus {
     TomtFødselsnummer = 'Vennligst fyll ut fødselsnummer',
@@ -26,7 +26,7 @@ const useAktørId = (fnr: string, sjekkerTilgangOgEksistens: boolean): AktørIdO
     const hentAktørIdOgSjekkTilgang = useCallback(async () => {
         try {
             validerFnr(fnr);
-            const gjeldendeAktørId = await hentAktørId(fnr);
+            const gjeldendeAktørId = await hentOgSjekkAktørId(fnr);
             await sjekkSkrivetilgang(gjeldendeAktørId);
             await sjekkKandidatEksisterer(gjeldendeAktørId);
             setAktørId(gjeldendeAktørId);
@@ -57,10 +57,10 @@ const validerFnr = (fnr: string) => {
     }
 };
 
-const hentAktørId = async (fnr: string) => {
+const hentOgSjekkAktørId = async (fnr: string) => {
     let respons;
     try {
-        respons = await hentAktørIdDirekte(fnr);
+        respons = await hentAktørId(fnr);
     } catch (error) {
         throw TilgangsStatus.Serverfeil;
     }

--- a/src/pages/registrering/Registrering.tsx
+++ b/src/pages/registrering/Registrering.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FormEvent, FunctionComponent, useEffect } from 'react';
+import React, { useState, FormEvent, FunctionComponent } from 'react';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { withRouter, RouteComponentProps } from 'react-router';
 
@@ -10,7 +10,7 @@ import {
     GrunnleggendeBehov,
     Behovfelt,
 } from '../../types/Behov';
-import { hentFnr, opprettKandidat } from '../../api/finnKandidatApi';
+import { opprettKandidat } from '../../api/finnKandidatApi';
 import Arbeidsmiljø from './arbeidsmiljø/Arbeidsmiljø';
 import Arbeidstid from './arbeidstid/Arbeidstid';
 import bemHelper from '../../utils/bemHelper';
@@ -21,6 +21,7 @@ import Informasjon from './informasjon/Informasjon';
 import { Kandidat } from '../../types/Kandidat';
 import RouteBanner from '../../components/route-banner/RouteBanner';
 import './registrering.less';
+import useFnr from './useFnr';
 
 const cls = bemHelper('registrering');
 
@@ -33,15 +34,7 @@ const Registrering: FunctionComponent<RouteComponentProps<MatchProps>> = ({ hist
     const [grunnleggendeBehov, setGrunnleggendeBehov] = useState<GrunnleggendeBehov[]>([]);
     const [isSubmitting, setSubmitting] = useState<boolean>(false);
     const [feilmelding, setFeilmelding] = useState<string | undefined>(undefined);
-    const [fnr, setFnr] = useState<string>('');
-
-    useEffect(() => {
-        const hentOgSettFnr = async () => {
-            const respons = await hentFnr(aktørId);
-            setFnr(respons.data);
-        };
-        hentOgSettFnr();
-    }, [aktørId]);
+    const fnr = useFnr(aktørId);
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();

--- a/src/pages/registrering/useFnr.ts
+++ b/src/pages/registrering/useFnr.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from 'react';
+import { hentFnr } from '../../api/aktørregisterApi';
+import { TilgangsStatus } from '../før-du-begynner/useAktørId';
+import { hentGjeldendeIdent } from '../../api/aktørregisterUtils';
+
+const useFnr = (aktørId: string): string => {
+    const [fnr, setFnr] = useState<string>('');
+
+    const hentOgSettFnr = useCallback(async () => {
+        try {
+            const fnr = await hentOgSjekkFnr(aktørId);
+            setFnr(fnr);
+        } catch (ignored) {}
+    }, [aktørId]);
+
+    useEffect(() => {
+        hentOgSettFnr();
+    }, [hentOgSettFnr]);
+
+    return fnr;
+};
+
+const hentOgSjekkFnr = async (aktørId: string) => {
+    let respons;
+    try {
+        respons = await hentFnr(aktørId);
+    } catch (error) {
+        // Hva skal skje om dette ikke går?
+        throw TilgangsStatus.Serverfeil;
+    }
+
+    // TODO Helt duplisert fra aktørIdKall
+    const fnrFinnesIkke = !respons.data[aktørId];
+    const ingenIdenter = respons.data[aktørId] && !respons.data[aktørId].identer;
+    if (fnrFinnesIkke || ingenIdenter) {
+        throw TilgangsStatus.IngenTilgangEllerIkkeFinnes;
+    }
+
+    const gjeldendeFnr = hentGjeldendeIdent(aktørId, respons);
+    if (gjeldendeFnr) {
+        return gjeldendeFnr;
+    } else {
+        throw TilgangsStatus.Serverfeil;
+    }
+};
+
+export default useFnr;

--- a/src/pages/registrering/useFnr.ts
+++ b/src/pages/registrering/useFnr.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { hentFnr } from '../../api/aktørregisterApi';
-import { TilgangsStatus } from '../før-du-begynner/useAktørId';
+import { Feilmelding } from '../før-du-begynner/useAktørId';
 import { hentGjeldendeIdent } from '../../api/aktørregisterUtils';
 
 const useFnr = (aktørId: string): string => {
@@ -26,21 +26,21 @@ const hentOgSjekkFnr = async (aktørId: string) => {
         respons = await hentFnr(aktørId);
     } catch (error) {
         // Hva skal skje om dette ikke går?
-        throw TilgangsStatus.Serverfeil;
+        throw Feilmelding.Serverfeil;
     }
 
     // TODO Helt duplisert fra aktørIdKall
     const fnrFinnesIkke = !respons.data[aktørId];
     const ingenIdenter = respons.data[aktørId] && !respons.data[aktørId].identer;
     if (fnrFinnesIkke || ingenIdenter) {
-        throw TilgangsStatus.IngenTilgangEllerIkkeFinnes;
+        throw Feilmelding.IngenTilgangEllerIkkeFinnes;
     }
 
     const gjeldendeFnr = hentGjeldendeIdent(aktørId, respons);
     if (gjeldendeFnr) {
         return gjeldendeFnr;
     } else {
-        throw TilgangsStatus.Serverfeil;
+        throw Feilmelding.Serverfeil;
     }
 };
 

--- a/src/server/aktørregisterProxy.js
+++ b/src/server/aktørregisterProxy.js
@@ -1,30 +1,15 @@
 const proxy = require('http-proxy-middleware');
 
-// Mock backend ligger på port 8081
 const aktørregisterUrl = process.env.AKTORREGISTER_URL || 'http://localhost:8081';
 
 const proxyConfig = {
     changeOrigin: true,
     target: aktørregisterUrl,
-    // ex fra https://arbeidsgiver.adeo.no/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true
-    //    til https://app.adeo.no/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true
-    // TODO: Fiks URL navn i nais filer
     pathRewrite: {
         '^/finn-kandidat': '',
     },
     secure: true,
-    xfwd: true,
-    logLevel: 'debug',
-    // TODO: Fjern logging
-    onProxyReq: function onProxyReq(proxyReq, req, res) {
-        // Log outbound request to remote target
-        console.log('-->  ', req.method, req.path, '->', proxyReq.baseUrl + proxyReq.path);
-    },
-    onError: function onError(err, req, res) {
-        console.error(err);
-        res.status(500);
-        res.json({error: 'Error when connecting to remote server.'});
-    },
+    xfwd: true
 };
 
 module.exports = proxy(proxyConfig);

--- a/src/server/aktørregisterProxy.js
+++ b/src/server/aktørregisterProxy.js
@@ -1,0 +1,30 @@
+const proxy = require('http-proxy-middleware');
+
+// Mock backend ligger på port 8081
+const aktørregisterUrl = process.env.AKTORREGISTER_URL || 'http://localhost:8081';
+
+const proxyConfig = {
+    changeOrigin: true,
+    target: aktørregisterUrl,
+    // ex fra https://arbeidsgiver.adeo.no/finn-kandidat/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true
+    //    til https://app.adeo.no/aktoerregister/api/v1/identer?identgruppe=AktoerId&gjeldende=true
+    // TODO: Fiks URL navn i nais filer
+    pathRewrite: {
+        '^/finn-kandidat': '',
+    },
+    secure: true,
+    xfwd: true,
+    logLevel: 'debug',
+    // TODO: Fjern logging
+    onProxyReq: function onProxyReq(proxyReq, req, res) {
+        // Log outbound request to remote target
+        console.log('-->  ', req.method, req.path, '->', proxyReq.baseUrl + proxyReq.path);
+    },
+    onError: function onError(err, req, res) {
+        console.error(err);
+        res.status(500);
+        res.json({error: 'Error when connecting to remote server.'});
+    },
+};
+
+module.exports = proxy(proxyConfig);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const express = require('express');
+const aktørregisterProxy = require('./aktørregisterProxy');
 const app = express();
 
 const DEFAULT_PORT = 3000;
@@ -11,6 +12,7 @@ const LOCAL_LOGIN = `http://localhost:8080/finn-kandidat-api/local/isso-login?re
 const buildPath = path.join(__dirname, '../../build');
 
 const startServer = () => {
+    app.use(`${BASE_PATH}/aktoerregister`, aktørregisterProxy);
     app.use(BASE_PATH, express.static(buildPath));
 
     app.get(`${BASE_PATH}/internal/isAlive`, (req, res) => res.sendStatus(200));
@@ -23,7 +25,6 @@ const startServer = () => {
     app.use(BASE_PATH, (_, res) => {
         res.sendFile(path.resolve(buildPath, 'index.html'));
     });
-
     app.use('/', (_, res) => {
         res.redirect(BASE_PATH);
     });

--- a/src/utils/randomIdUtils.ts
+++ b/src/utils/randomIdUtils.ts
@@ -1,0 +1,14 @@
+declare global {
+    interface Window {
+        msCrypto: {};
+    }
+}
+
+export const randomCallId = () => {
+    let idx = 0;
+    const c = window.crypto || window.msCrypto;
+    const rnd = Array.from(c.getRandomValues(new Uint8Array(32))).map(value =>
+        (value & 15).toString(16)
+    );
+    return '00000000-0000-0000-0000-000000000000'.replace(/0/g, () => rnd[idx++]);
+};


### PR DESCRIPTION
Oversetter mellom aktørId og fnr med kall til aktørregister gjennom node proxyen.
Dette kan på sikt forenkle mye av koden i backenden.